### PR TITLE
Changed apiKey option to password type

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -44,7 +44,7 @@ module.exports = {
       name: 'API Key',
       description: 'Your Google Maps API Key',
       default: '',
-      type: 'text',
+      type: 'password',
       userCanEdit: true,
       adminOnly: false
     }


### PR DESCRIPTION
## Steps to Test
- Verify when you add the api key option that the option is a password type